### PR TITLE
Addon Manager refers to non-existing branch

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
   <date>2022-06-11</date>
   <maintainer email="sppedflyer@gmail.com">looooo</maintainer>
   <license file="LICENSE">LGPL 2.1</license>
-  <url type="repository" branch="develop">https://github.com/looooo/freecad.frametools</url>
+  <url type="repository" branch="master">https://github.com/looooo/freecad.frametools</url>
   <url type="bugtracker">https://github.com/looooo/freecad.frametools/issues</url>
   <url type="documentation">https://github.com/looooo/freecad.frametools</url>
   <icon>freecad/frametools/icons/beam.svg</icon>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/365338/197382691-40120158-45f1-456c-94d0-99f0b378d295.png)


Fix by pointing it to master branch instead of develop