### PR TITLE
Update add-on metadata

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,24 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
-  <name>freecad.frametools workbench</name>
+
+  <name>Frame and beams workbench</name>
+
   <description>A workbench for beams and frames</description>
-  <version>0.1.0</version>
-  <date>2022-06-11</date>
+
+  <version>0.1.1</version>
+
+  <date>2023-08-08</date>
+
   <maintainer email="sppedflyer@gmail.com">looooo</maintainer>
+
   <license file="LICENSE">LGPL 2.1</license>
-  <url type="repository" branch="develop">https://github.com/looooo/freecad.frametools</url>
+
+  <url branch="master" type="repository">https://github.com/looooo/freecad.frametools</url>
+
   <url type="bugtracker">https://github.com/looooo/freecad.frametools/issues</url>
+
+  <url type="readme">https://github.com/looooo/freecad.frametools/blob/master/README.md</url>
+
   <url type="documentation">https://github.com/looooo/freecad.frametools</url>
+
   <icon>freecad/frametools/icons/beam.svg</icon>
 
   <content>
     <workbench>
-      <classname>FrameWorkbench</classname>
-      <subdirectory>./</subdirectory>
-      <freecadmin>0.19</freecadmin>
+      <freecadmin>0.19.0</freecadmin>
+      <depend optional="False" type="automatic">scipy</depend>
       <tag>frame</tag>
       <tag>beam</tag>
-      <depend>scipy</depend>
+      <classname>FrameWorkbench</classname>
+      <subdirectory>./</subdirectory>
     </workbench>
   </content>
 


### PR DESCRIPTION
The following changes are done:

* Name changed to "Frame and beams workbench" to look it nicer in Add-on Manager.
* Added URL to `README.md` to have a description in Add-on Manager.
* Version changed to 0.1.1 to differentiate from previous changes.

In addition I would like to suggest to:

* Set tag with name like `version-0.1.1` on commit after merge of this PR to track version history.
* Update version after changes to show users that something changes.

Thanks.