### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
 
   <maintainer email="sppedflyer@gmail.com">looooo</maintainer>
 
-  <license file="LICENSE">LGPL 2.1</license>
+  <license file="LICENSE">LGPL-2.1-or-later</license>
 
   <url branch="master" type="repository">https://github.com/looooo/freecad.frametools</url>
 


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean `LGPL-2.1-only`, in which case use that instead.
